### PR TITLE
Error handling crawler

### DIFF
--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -75,6 +75,12 @@ namespace {
 
 			if(boost::to_lower_copy(title.substr(0,5)) == "talk:")
 				title = title.substr(5);
+            
+            // removes any underscores
+            std::string delim = "_";
+            auto end = title.find(delim);
+            if (end != std::string::npos)
+                std::replace(title.begin(), title.end(), '_', ' ');
 		}
 	}	
 }
@@ -98,6 +104,7 @@ namespace Grawitas {
 			for(std::size_t i = 0; i < N_PAGES_PER_REQUEST; i++)
 			{
 				auto& page = page_progress[i % page_progress.size()];
+                //std::cout << "Page:" << page.first << "\n";
 				if(page.second == 0)
 					current_titles.push_back("Talk:" + page.first);
 				else
@@ -131,8 +138,8 @@ namespace Grawitas {
 			// parse every talk page and add it to partially_parsed_articles
 			for(const auto& result : results) 
 			{
-				if(result.missing || result.invalid)
-					continue; 
+				if(result.missing)
+					continue;
 
 				if(options.status_callback)
 					options.status_callback("Parsing '" + result.full_title + "'.");
@@ -145,14 +152,20 @@ namespace Grawitas {
 			// remove pages that returned missing from page_progress
 			for(const auto& result : results) 
 			{
-				if(!result.missing && !result.invalid)
+				if(!result.missing)
 					continue;
-
+                
 				// remove all remaining once from next_pages_to_crawl
-				page_progress.erase(std::remove_if(page_progress.begin(), page_progress.end(), [&result](const std::pair<std::string,int>& page) { 
+				page_progress.erase(std::remove_if(page_progress.begin(), page_progress.end(), [&result](const std::pair<std::string,int>& page) {
 					return page.first == result.title;
 				}), page_progress.end());
+                
+                // additional condition for when there is only one page remaining and it is a missing page 
+                if((page_progress.size() == 1))
+                    page_progress.clear();
+                
 			}
+            
 
 			// export those articles that are finished and remove them
 			for(const auto& result : results) 

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -131,7 +131,7 @@ namespace Grawitas {
 			// parse every talk page and add it to partially_parsed_articles
 			for(const auto& result : results) 
 			{
-				if(result.missing)
+				if(result.missing || result.invalid)
 					continue; 
 
 				if(options.status_callback)
@@ -145,7 +145,7 @@ namespace Grawitas {
 			// remove pages that returned missing from page_progress
 			for(const auto& result : results) 
 			{
-				if(!result.missing)
+				if(!result.missing && !result.invalid)
 					continue;
 
 				// remove all remaining once from next_pages_to_crawl

--- a/src/httpCrawler/getPagesFromWikipedia.cpp
+++ b/src/httpCrawler/getPagesFromWikipedia.cpp
@@ -119,6 +119,7 @@ std::vector<TalkPageResult> get_pages_from_wikipedia(std::vector<std::string> pa
 		TalkPageResult result;
 		auto t = page.second;			
 		result.missing = t.count("missing");
+        result.invalid = t.count("invalid");
 		result.full_title = t.get<std::string>("title");
 
 		auto tmp = parse_page_title(result.full_title);
@@ -126,8 +127,9 @@ std::vector<TalkPageResult> get_pages_from_wikipedia(std::vector<std::string> pa
 		result.is_archive = std::get<1>(tmp);
 		result.i_archive = std::get<2>(tmp);
 
-		if(!result.missing)
+		if(!(result.missing && result.invalid))
 			result.content = t.get_child("revisions").front().second.get<std::string>("*");
+        
 
 		results.push_back(result);
 	}

--- a/src/httpCrawler/getPagesFromWikipedia.h
+++ b/src/httpCrawler/getPagesFromWikipedia.h
@@ -5,6 +5,7 @@
 
 struct TalkPageResult {
 	bool missing;
+    bool invalid; 
 	bool is_archive;
 	int i_archive;
 

--- a/src/httpCrawler/getPagesFromWikipedia.h
+++ b/src/httpCrawler/getPagesFromWikipedia.h
@@ -5,7 +5,6 @@
 
 struct TalkPageResult {
 	bool missing;
-    bool invalid; 
 	bool is_archive;
 	int i_archive;
 


### PR DESCRIPTION
- Added an error message that outputs if a page has been deleted or not found by the crawler 
- Added an additional condition to the crawling.cpp to allow it to handle when the last page in each batch of 10 pages is missing in order to prevent an infinite loop 
- sanitise_titles now strips any underscores out of article titles and replaces them with whitespace 